### PR TITLE
[#98365398] Support for GCE. Upgraded WAL-E to 0.8.0 and added more environment v…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is the list of variables used in this role and their defaults
 
 AWS configuration (required):
 
- * `wal_e_s3_prefix` set the bucket url and prefix where store the values.
+ * `wal_e_s3_prefix` set the bucket url and prefix where to store the values.
     More info in [WAL-E Documentation](https://github.com/wal-e/wal-e#backend-blob-store)
 
  * `wal_e_aws_instance_profile: false` Set it to `true` to enable IAM instance profiles.
@@ -30,9 +30,20 @@ AWS configuration (required):
 
  * `wal_e_aws_access_key` and `wal_e_aws_secret_key` AWS S3 credentials
 
+GCE configuration:
+
+ * `wal_e_s3_prefix` the same as AWS. However, do not use dots in the bucket name, use hyphens instead dots.
+
+ * `wal_e_aws_instance_profile: false` This must stay as false as we will not use IAM instance profile.
+
+ * `wal_e_aws_access_key` and `wal_e_aws_secret_key` Google Storage access key and secret. These can be generated from `Interoperability` tab in Google Storage dashboard.
+
+ * `wal_e_s3_endpoint` set it to "http+path://storage.googleapis.com". GS has interoperability mode which has identical interface to S3.
+
+
 Installation options:
 
- * `wal_e_version: 0.7.0` version of WAL-E to install
+ * `wal_e_version: 0.8.0` version of WAL-E to install
  * `wal_e_pgdata_dir: '/var/lib/postgresql/9.1/main/'` location of the backup data
 
 
@@ -92,4 +103,3 @@ License
 -------
 
 See LICENSE file.
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ wal_e_pips:
   - six==1.9.0
   - requests==2.5.2
 
-wal_e_version: 0.7.0
+wal_e_version: 0.8.0
 
 wal_e_envdir: '/etc/wal-e'
 
@@ -48,4 +48,3 @@ wal_e_aws_instance_profile: false
 # Recommended store this using ansible-vault (http://docs.ansible.com/playbooks_vault.html)
 wal_e_aws_access_key:
 wal_e_aws_secret_key:
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,13 +25,13 @@
     owner="{{ wal_e_user}}"
     group="{{ wal_e_group }}"
     mode=0600
-  when: wal_e_aws_access_key
+  when: wal_e_aws_access_key|default("") != ""
 
 - name: setup AWS credentials AWS_ACCESS_KEY_ID
   file: |
     state=absent
     path="{{ wal_e_envdir }}/AWS_ACCESS_KEY_ID"
-  when: not wal_e_aws_access_key
+  when: wal_e_aws_access_key|default("") == ""
 
 - name: setup AWS credentials AWS_SECRET_ACCESS_KEY
   copy: |
@@ -40,13 +40,28 @@
     owner="{{ wal_e_user}}"
     group="{{ wal_e_group }}"
     mode=0600
-  when: wal_e_aws_secret_key
+  when: wal_e_aws_secret_key|default("") != ""
 
-- name: setup AWS credentials AWS_SECRET_KEY_ID
+- name: setup AWS credentials AWS_SECRET_ACCESS_KEY
   file: |
     state=absent
-    path="{{ wal_e_envdir }}/AWS_SECRET_KEY_ID"
-  when: not wal_e_aws_secret_key
+    path="{{ wal_e_envdir }}/AWS_SECRET_ACCESS_KEY"
+  when: wal_e_aws_secret_key|default("") == ""
+
+- name: setup WAL-E S3 endpoint
+  copy: |
+    content="{{ wal_e_s3_endpoint }}"
+    dest="{{ wal_e_envdir }}/WALE_S3_ENDPOINT"
+    owner="{{ wal_e_user}}"
+    group="{{ wal_e_group }}"
+    mode=0600
+  when: wal_e_s3_endpoint|default("") != ""
+
+- name: setup WAL-E S3 endpoint
+  file: |
+    state=absent
+    path="{{ wal_e_envdir }}/WALE_S3_ENDPOINT"
+  when: wal_e_s3_endpoint|default("") == ""
 
 - name: setup WAL-E S3 bucket prefix
   copy: |


### PR DESCRIPTION
We want this playbook to support deployment on GCE as well.

This requires small changes. Version of WAL-E needs to be upgraded to 0.8.0 in order to support new variable WALE_S3_ENDPOINT. We use this variable to change S3 endpoint to Google Storage.

I have also fixed conditional environment variables written to /etc/wal-e. If wal_e_aws_access_key or wal_e_aws_secret_key were set in tsuru-ansible, this did not work as previous use of "when" conditional would be only correct for true/false values.
# Who should review

Anyone except @RichardKnop
# How to review
-  Apply to a GCE environment. There will be a new PR for tsuru-ansible, in the meanwhile just add this on the bottom of platform.gce.yml:
  
  ```
  enable_postgres_log_shipping: true
  postgresql_wal_level: hot_standby
  postgresql_archive_mode: on
  postgres_backup_s3_bucket: "{{ deploy_env }}-mcp-postgres-backup"
  wal_e_aws_instance_profile: false
  wal_e_aws_access_key: "{{ gs_access_key }}"
  wal_e_aws_secret_key: "{{ gs_secret }}"
  postgresql_archive_command: "/usr/bin/envdir {{ wal_e_envdir }} /usr/local/bin/wal-e {% if wal_e_aws_instance_profile %}--aws-instance-profile{% endif %} wal-push %p"
  wal_e_s3_endpoint: "http+path://storage.googleapis.com"
  wal_e_s3_prefix: "s3://{{ postgres_backup_s3_bucket }}/wal-e"
  wal_e_pgdata_dir: "/var/lib/postgresql/{{ postgresql_version }}/main/"
  ```
  
  You also need to add `gs_access_key` and `gs_secret` to the vault file (again this will be part of another PR).
- Check /etc/wal-e contains all 4 environment variables
- Check that WAL-E is version 0.8.0:
  
  ```
  pip freeze | grep wal-e
  ```
