### PR TITLE
[#98371938] remove backup cron when backup disabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,4 +83,4 @@
     month="{{ wal_e_base_backup_month }}"
     user="{{ wal_e_user }}"
     job="/usr/bin/envdir {{ wal_e_envdir }} /usr/local/bin/wal-e {% if wal_e_aws_instance_profile %}--aws-instance-profile{% endif %} backup-push {{wal_e_base_backup_options}} {{ wal_e_pgdata_dir }}"
-  when: not wal_e_base_backup_disabled
+    state="{% if wal_e_base_backup_disabled %}absent{% else %}present{% endif %}"


### PR DESCRIPTION
Changed condition on crontab creation to also remove it when the server is not supposed to do backup. This way backup cron would be removed when e.g. server switches into standby role.
