### PR TITLE
[#99686132] Delete old Postgres backups

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,15 @@ wal_e_base_backup_weekday:  '1'
 
 wal_e_base_backup_options: ''
 
+wal_e_backup_delete_disabled: false
+wal_e_backup_delete_minute:   '0'
+wal_e_backup_delete_hour:     '0'
+wal_e_backup_delete_day:      '*'
+wal_e_backup_delete_month:    '*'
+wal_e_backup_delete_weekday:  '*'
+
+wal_e_backup_delete_retain: '5'
+
 wal_e_user: 'postgres'
 wal_e_group: 'postgres'
 wal_e_pgdata_dir: '/var/lib/postgresql/9.1/main/'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,3 +84,17 @@
     user="{{ wal_e_user }}"
     job="/usr/bin/envdir {{ wal_e_envdir }} /usr/local/bin/wal-e {% if wal_e_aws_instance_profile %}--aws-instance-profile{% endif %} backup-push {{wal_e_base_backup_options}} {{ wal_e_pgdata_dir }}"
     state="{% if wal_e_base_backup_disabled %}absent{% else %}present{% endif %}"
+
+# Creates a cron file under /etc/cron.d
+- name: Setup cron job for the rotation of backups
+  cron: |
+    name=wal_e_backup_delete
+    cron_file=wal_e_backup_delete
+    minute="{{ wal_e_backup_delete_minute }}"
+    hour="{{ wal_e_backup_delete_hour }}"
+    day="{{ wal_e_backup_delete_day }}"
+    weekday="{{ wal_e_backup_delete_weekday}}"
+    month="{{ wal_e_backup_delete_month }}"
+    user="{{ wal_e_user }}"
+    job="/usr/bin/envdir {{ wal_e_envdir }} /usr/local/bin/wal-e {% if wal_e_aws_instance_profile %}--aws-instance-profile{% endif %} delete --confirm retain {{wal_e_backup_delete_retain}}"
+    state="{% if wal_e_backup_delete_disabled %}absent{% else %}present{% endif %}"


### PR DESCRIPTION
# What

A new cron job is created which runs every day in `/etc/cron.d/wal_e_backup_delete`.

The cron job invokes WAL-E's `delete` subcommand which deletes all backups older than number we want to retain, as well as the archived WAL files older than that.

Based on a variable called `wal_e_backup_delete_retain` it will keep that number of backups and delete the rest.
# How To Test

Go to your `tsuru-ansible` directory and change the version of `ansible-playbook-wal-e` to point to this PR in `requirements.yml`.

Install Ansible Galaxy requirements:

```
ansible-galaxy install -r requirements.yml --force
```

Then, provision the Postgres master. For example, given you have an AWS environment called `michael`:

```
ansible-playbook -i ec2.py postgres.yml -e "@platform-aws.yml" -e "deploy_env=michael"
```

Now ssh to the Postgres box. You can find the IP by running something like `./ec2.py | grep postgres -C 2`.

Make sure the cron job has been created:

```
ls /etc/cron.d/wal_e_backup_delete
```

Change user to postgres:

```
sudo su postgres -
```

Now create several backups by running the backup-push command:

```
/usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e --aws-instance-profile backup-push  /var/lib/postgresql/9.3/main/
```

You can always review backups by running the backup-list command:

```
/usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e --aws-instance-profile backup-list
```

Generate more than 5 backups and try running:

```
/usr/bin/envdir /etc/wal-e /usr/local/bin/wal-e --aws-instance-profile delete --confirm retain 5
```

Old backups should be deleted and 5 should be retained.
# Who To Review

Somebody other than @RichardKnop or @russss.
